### PR TITLE
Add MPU6050 accelerometer integration with FastIMU library

### DIFF
--- a/MSCanBus.h
+++ b/MSCanBus.h
@@ -1,3 +1,9 @@
+#include <ESP32-TWAI-CAN.hpp>
+#include "qqqlab_GPS_UBLOX.h"
+#include "FastIMU.h"
+#include <Wire.h>
+#include <stdarg.h>
+
 // Megasquirt Message Types
 #define MSG_CMD 0    // Command
 #define MSG_REQ 1    // Request

--- a/MSCanBus.ino
+++ b/MSCanBus.ino
@@ -1,10 +1,10 @@
-#include <ESP32-TWAI-CAN.hpp>
-#include "qqqlab_GPS_UBLOX.h"
 #include "MSCanBus.h"
 
 #define DEBUG false
 
 // Hardware pins
+#define IMU_SDA 25
+#define IMU_SCL 26
 #define GPS_RX 16
 #define GPS_TX 17
 #define CAN_RX 21
@@ -17,16 +17,33 @@
 #define CAN_TIMEOUT 25    // ms, default is 1000
 
 // MegaSquirt CAN IDs
-#define MY_CAN_ID 10
 #define MS_CAN_ID 0
-#define MS_CAN_TBL 7
+#define MY_CAN_ID 10
+#define MY_CAN_TBL 7
 
+// IMU settings
+#define IMU_ADDRESS 0x68  //Change to the address of the IMU
+#define IMU_GEOMETRY 0    //Change to your current IMU geometry (check docs for a reference pic).
+MPU6050 IMU;              //Change to the name of any supported IMU, check the docs for the supported IMUs
+
+// GPS settings
+#define GPS_RATE_MS 100    // gps update rate in milliseconds (default 100)
+#define GPS_SAVE_CONFIG 2  // save config  0:Do not save config, 1:Save config, 2:Save only when needed (default 2)
+#define GPS_GNSS_MODE 77   // GNSS system(s) to use  Bitmask: 1:GPS, 2:SBAS, 4:Galileo, 8:Beidou, 16:IMES, 32:QZSS, 64:GLONASS (default 0=leave as configured)
+
+/* =================================== Do not change bellow ============================================ */
 // Global objects
 HardwareSerial GPS(1);
 
 CanFrame rxmsg, txmsg;
 msg_req_data_raw msg_req_data;
 msg_packed rxmsg_id, txmsg_id;
+
+
+calData calib = { 0 };  // Calibration data
+AccelData accelData;    // Accell Sensor data
+GyroData gyroData;      // Gyro Sensor data
+bool IMU_OK = false;    // Do not change it!
 
 
 class GPS_UBLOX : public AP_GPS_UBLOX {
@@ -57,7 +74,7 @@ public:
     return ::millis();
   }
   void I_print(const char *str) override {
-    Serial.print("[AP_GPS_UBLOX] ");
+    Serial.print(F("[AP_GPS_UBLOX] "));
     Serial.print(str);
   }
 } gps;
@@ -77,7 +94,7 @@ location convert(long loc) {
 void sendCANResponse(uint8_t *data, uint8_t length = 8, const char *debugMsg = nullptr) {
   // Validate inputs
   if (!data || length > 8) {
-    if (DEBUG) Serial.println("[ERROR] Invalid CAN response data");
+    if (DEBUG) Serial.println(F("[ERROR] Invalid CAN response data"));
     return;
   }
 
@@ -89,13 +106,13 @@ void sendCANResponse(uint8_t *data, uint8_t length = 8, const char *debugMsg = n
 
   // Debug output
   if (DEBUG && debugMsg) {
-    Serial.printf("[CAN TX] %s: Block=%d Offset=%d Data=[",
+    Serial.printf(F("[CAN TX] %s: Block=%d Offset=%d Data=["),
                   debugMsg, rxmsg_id.values.block, rxmsg_id.values.offset);
     for (int i = 0; i < length; i++) {
       Serial.printf("%02X", data[i]);
-      if (i < length - 1) Serial.print(" ");
+      if (i < length - 1) Serial.print(F(" "));
     }
-    Serial.println("]");
+    Serial.println(F("]"));
   }
 }
 
@@ -103,132 +120,193 @@ void parseCAN() {
   bool time_valid = gps.state.valid >> 2 & 1;
   bool gps_fix_ok = gps.state.status > 1;
   if (ESP32Can.readFrame(rxmsg, CAN_TIMEOUT)) {
-    if (!rxmsg.extd) return;  // Only handle extended frames
+    if (!rxmsg.extd) return;  // Only handle extended frames with proper data
     rxmsg_id.i = rxmsg.identifier;
-    if (DEBUG) Serial.printf(" Got a CAN Frame for: %d", rxmsg_id.values.to_id);
-    if (rxmsg_id.values.to_id == MY_CAN_ID && rxmsg_id.values.msg_type == MSG_REQ) {
-      if (DEBUG) Serial.println(" Got CAN Req ");
+    if (DEBUG) Serial.printf(F("CAN Frame for: %d\n"), rxmsg_id.values.to_id);
+    if (rxmsg_id.values.to_id != MY_CAN_ID && rxmsg_id.values.msg_type != MSG_REQ) {
+      if (DEBUG) Serial.printf(F("CAN Msg Type: %d\n"), rxmsg_id.values.msg_type);
+      return;
+    }
+    // Pack MSG_RSP header into the first 3 data bytes
+    memcpy(&msg_req_data.bytes, rxmsg.data, 3);
 
-      // Pack MSG_RSP header into the first 3 data bytes
-      memcpy(&msg_req_data.bytes, rxmsg.data, 3);
+    if (rxmsg_id.values.block != MY_CAN_TBL) {
+      if (DEBUG) Serial.printf(F("CAN Msg Type: %d\n"), rxmsg_id.values.block);
+      return;  // not our CAN table
+    }
 
-      if (rxmsg_id.values.block != MS_CAN_TBL) return;  // not our CAN table
+    // Create the tx packet header
+    createTXHeader();
 
-      // Create the tx packet header
-      txmsg_id.values.block = msg_req_data.values.varblk;
-      txmsg_id.values.offset = msg_req_data.values.varoffset;
-      txmsg.identifier = txmsg_id.i;
+    switch (rxmsg_id.values.offset) {
+      case 2:
+        {  // ADC 1-4 - accelerometer
+          if (IMU_OK) {
+            // normalize +/- 4G to a 12 bit unsigned int value
+            uint16_t accelX = constrain((accelData.accelX / 9.8 * 1023) + 2047, 0, 4095);
+            uint16_t accelY = constrain((accelData.accelY / 9.8 * 1023) + 2047, 0, 4095);
+            uint16_t accelZ = constrain((accelData.accelZ / 9.8 * 1023) + 2047, 0, 4095);
 
-      switch (rxmsg_id.values.offset) {
-        case 2:
-          {                                // ADC 1-4 - accelerometer
-            uint8_t accelData[8] = { 0 };  // Not implemented - send zeros
-            //sendCANResponse(accelData, 8, "Accel Req");
-            break;
+            uint8_t accelBytes[8] = { accelX / 256, accelX % 256, accelY / 256,
+                                      accelY % 256, accelZ / 256, accelZ % 256, 0, 0 };
+            sendCANResponse(accelBytes, 8, "Accel Req");
           }
-        case 110:
-          {  // realtime clock
-            if (!time_valid) break;
-            uint8_t timeData[8] = { gps.state.sec, gps.state.min, gps.state.hour, 0,
-                                    gps.state.day, gps.state.month,
-                                    gps.state.year / 256, gps.state.year % 256 };
-            sendCANResponse(timeData, 8, "Time Req");
-            break;
-          }
-        case 128:
-          {  // gps1 - coordinates
-            if (!gps_fix_ok) break;
-            location lat = convert(gps.state.lat);
-            location lng = convert(gps.state.lng);
-            uint8_t gpsData[8] = { lat.deg, lat.min, lat.mmin / 256, lat.mmin % 256,
-                                   lng.deg, lng.min, lng.mmin / 256, lng.mmin % 256 };
-            sendCANResponse(gpsData, 8, "GPS1 Req");
-            break;
-          }
-        case 136:
-          {  // gps2 - status/altitude/speed
-            uint8_t statusData[8];
-            statusData[0] = (gps.state.lng < 0 ? 1 : 0) + (gps_fix_ok ? 2 : 0);
-            statusData[1] = round(gps.state.alt / 1000000);
-            statusData[2] = round(gps.state.alt / 100) / 256;
-            statusData[3] = (int)round(gps.state.alt / 100) % 256;
-            statusData[4] = round(gps.state.ground_speed / 100) / 256;
-            statusData[5] = (int)round(gps.state.ground_speed / 100) % 256;
-            statusData[6] = gps.state.ground_course / 256;
-            statusData[7] = gps.state.ground_course % 256;
-            sendCANResponse(statusData, 8, "GPS2 Req");
-            break;
-          }
-      }
+          break;
+        }
+      case 110:
+        {  // realtime clock
+          if (!time_valid) break;
+          uint8_t timeData[8] = { gps.state.sec, gps.state.min, gps.state.hour, gps.state.day,
+                                  gps.state.day, gps.state.month,
+                                  gps.state.year / 256, gps.state.year % 256 };
+          sendCANResponse(timeData, 8, "Time Req");
+          break;
+        }
+      case 128:
+        {  // gps1 - coordinates
+          if (!gps_fix_ok) break;
+          location lat = convert(gps.state.lat);
+          location lng = convert(gps.state.lng);
+          uint8_t gpsData[8] = { lat.deg, lat.min, lat.mmin / 256, lat.mmin % 256,
+                                 lng.deg, lng.min, lng.mmin / 256, lng.mmin % 256 };
+          sendCANResponse(gpsData, 8, "GPS1 Req");
+          break;
+        }
+      case 136:
+        {  // gps2 - status/altitude/speed
+          if (!gps_fix_ok) break;
+          uint8_t statusData[8];
+          statusData[0] = (gps.state.lng < 0 ? 1 : 0) + (gps_fix_ok ? 2 : 0);
+          statusData[1] = round(gps.state.alt / 1000000);
+          statusData[2] = round(gps.state.alt / 100) / 256;
+          statusData[3] = (int)round(gps.state.alt / 100) % 256;
+          statusData[4] = round(gps.state.ground_speed / 100) / 256;
+          statusData[5] = (int)round(gps.state.ground_speed / 100) % 256;
+          statusData[6] = gps.state.ground_course / 256;
+          statusData[7] = gps.state.ground_course % 256;
+          sendCANResponse(statusData, 8, "GPS2 Req");
+          break;
+        }
+      default:
+        {
+          if (DEBUG) Serial.printf(F("CAN offset %d \n"), rxmsg_id.values.offset);
+        }
     }
   }
 }
+void createTXHeader() {
+  txmsg.extd = 1;
+  txmsg.data_length_code = 8;
+  txmsg_id.values.to_id = MS_CAN_ID;
+  txmsg_id.values.msg_type = MSG_RSP;
+  txmsg_id.values.from_id = MY_CAN_ID;
+  txmsg_id.values.block = msg_req_data.values.varblk;
+  txmsg_id.values.offset = msg_req_data.values.varoffset;
+  txmsg.identifier = txmsg_id.i;
+}
 
 void setup() {
+  // Setup gyro
+  Wire.begin(IMU_SDA, IMU_SCL);
+  Wire.setClock(400000);  //400khz clock
+
   Serial.begin(SERIAL_BAUD_RATE);
-  while (!Serial);
+  while (!Serial)
+    ;
 
   //start GPS Serial
   GPS.begin(GPS_BAUD_RATE, SERIAL_8N1, GPS_RX, GPS_TX);
 
+  // Init accelerometer gyro
+  IMU.setIMUGeometry(IMU_GEOMETRY);
+  int err = IMU.init(calib, IMU_ADDRESS);
+  if (err != 0) Serial.printf(F("Error initializing IMU: %d\n"), err);
+  else {
+    Serial.println(F("Starting IMU calibration..."));
+    uint32_t cal_start = millis();
+    IMU.calibrateAccelGyro(&calib);
+    IMU.init(calib, IMU_ADDRESS);
+    if (DEBUG) Serial.printf(F("Calibration completed in %dms\n"), millis() - cal_start);
+    IMU_OK = true;
+  }
+
   //start GPS
-  gps.rate_ms = 100;    //optional - gps update rate in milliseconds (default 100)
-  gps.save_config = 2;  //optional - save config  0:Do not save config, 1:Save config, 2:Save only when needed (default 2)
-  gps.gnss_mode = 77;   //optonial - GNSS system(s) to use  Bitmask: 1:GPS, 2:SBAS, 4:Galileo, 8:Beidou, 16:IMES, 32:QZSS, 64:GLONASS (default 0=leave as configured)
+  gps.rate_ms = GPS_RATE_MS;
+  gps.gnss_mode = GPS_GNSS_MODE;
+  gps.save_config = GPS_SAVE_CONFIG;
   gps.begin(&GPS);
 
   // Initialize CAN bus through bridge
   if (!ESP32Can.begin(ESP32Can.convertSpeed(500), CAN_TX, CAN_RX, 10, 10))
-    Serial.println("CAN bus failed!");
-
-  // Init the tx packet header
-  txmsg_id.values.msg_type = MSG_RSP;
-  txmsg_id.values.to_id = MS_CAN_ID;
-  txmsg_id.values.from_id = MY_CAN_ID;
-  txmsg.extd = 1;
-  txmsg.data_length_code = 8;
+    Serial.println(F("CAN bus failed!"));
 }
 
 void loop() {
+  static uint32_t ts = millis();
+
   // Update GPS data
   gps.update();
+
+  // Update IMU data
+  if (IMU_OK) {
+    IMU.update();
+    IMU.getAccel(&accelData);
+    IMU.getGyro(&gyroData);
+  }
+  // Debug output
+  if (DEBUG && millis() - ts > 1000) {
+    printGPSData();
+    printIMUData();
+    ts = millis();
+  }
   // Process CAN messages (MegaSquirt protocol)
   parseCAN();
-  // Print readable GPS status
-  static uint32_t ts = millis();
-  if (DEBUG && millis() - ts > 1000) {
-    ts = millis();
+}
 
-    // GPS fix status
-    const char *fixStatus;
-    switch (gps.state.status) {
-      case 0: fixStatus = "NO_GPS"; break;
-      case 1: fixStatus = "NO_FIX"; break;
-      case 2: fixStatus = "2D_FIX"; break;
-      case 3: fixStatus = "3D_FIX"; break;
-      case 4: fixStatus = "3D_DGPS"; break;
-      case 5: fixStatus = "RTK_FLOAT"; break;
-      case 6: fixStatus = "RTK_FIXED"; break;
-      default: fixStatus = "UNKNOWN"; break;
+void printIMUData() {
+  if (IMU_OK) {
+    Serial.printf(F("AccelX: %f "), accelData.accelX);
+    Serial.printf(F("AccelY: %f "), accelData.accelY);
+    Serial.printf(F("AccelZ: %f \n"), accelData.accelZ);
+    Serial.printf(F("GyroX: %f "), gyroData.gyroX);
+    Serial.printf(F("GyroY: %f "), gyroData.gyroY);
+    Serial.printf(F("GyroZ: %f \n"), gyroData.gyroZ);
+    if (IMU.hasTemperature()) {
+      Serial.printf(F("IMU Temp: %f \n"), IMU.getTemp());
     }
-
-    // Convert coordinates to readable format
-    double lat_deg = gps.state.lat / 10000000.0;
-    double lng_deg = gps.state.lng / 10000000.0;
-    double alt_m = gps.state.alt / 1000.0;
-    double speed_ms = gps.state.ground_speed / 1000.0;
-    double course_deg = gps.state.ground_course / 100000.0;
-
-    Serial.printf("Fix: %s | Satellites: %d | Time Valid: %s\n",
-                  fixStatus, gps.state.num_sats,
-                  (gps.state.valid >> 2 & 1) ? "YES" : "NO");
-    Serial.printf("Position: %.7f°, %.7f° | Altitude: %.1fm\n",
-                  lat_deg, lng_deg, alt_m);
-    Serial.printf("Speed: %.2fm/s | Course: %.1f° | H.Acc: %dmm\n",
-                  speed_ms, course_deg, (int)gps.state.horizontal_accuracy);
-    Serial.printf("Time: %02d:%02d:%02d %02d/%02d/%04d (GPS Week: %d)\n",
-                  gps.state.hour, gps.state.min, gps.state.sec,
-                  gps.state.month, gps.state.day, gps.state.year,
-                  (int)gps.state.time_week);
   }
+}
+
+void printGPSData() {
+  // GPS fix status
+  const __FlashStringHelper *fixStatus;
+  switch (gps.state.status) {
+    case 0: fixStatus = F("NO_GPS"); break;
+    case 1: fixStatus = F("NO_FIX"); break;
+    case 2: fixStatus = F("2D_FIX"); break;
+    case 3: fixStatus = F("3D_FIX"); break;
+    case 4: fixStatus = F("3D_DGPS"); break;
+    case 5: fixStatus = F("RTK_FLOAT"); break;
+    case 6: fixStatus = F("RTK_FIXED"); break;
+    default: fixStatus = F("UNKNOWN"); break;
+  }
+
+  // Convert coordinates to readable format
+  double lat_deg = gps.state.lat / 10000000.0;
+  double lng_deg = gps.state.lng / 10000000.0;
+  double alt_m = gps.state.alt / 1000.0;
+  double speed_ms = gps.state.ground_speed / 1000.0;
+  double course_deg = gps.state.ground_course / 100000.0;
+
+  Serial.printf(F("Fix: %s | Satellites: %d | Time Valid: %s\n"),
+                fixStatus, gps.state.num_sats,
+                (gps.state.valid >> 2 & 1) ? "YES" : "NO");
+  Serial.printf(F("Position: %.7f°, %.7f° | Altitude: %.1fm\n"),
+                lat_deg, lng_deg, alt_m);
+  Serial.printf(F("Speed: %.2fm/s | Course: %.1f° | H.Acc: %dmm\n"),
+                speed_ms, course_deg, (int)gps.state.horizontal_accuracy);
+  Serial.printf(F("Time: %02d:%02d:%02d %02d/%02d/%04d (GPS Week: %d)\n"),
+                gps.state.hour, gps.state.min, gps.state.sec,
+                gps.state.month, gps.state.day, gps.state.year,
+                (int)gps.state.time_week);
 }

--- a/README.md
+++ b/README.md
@@ -1,40 +1,40 @@
 # MSCanBus
 
-ESP32-based GPS CAN Bus implementation for MegaSquirt ECUs.
+ESP32-based GPS and Accelerometer CAN Bus implementation for MegaSquirt ECUs.
 
 ## Overview
 
-This project leverages the [ESP32](https://www.espressif.com/en/products/socs/esp32) microcontroller to interface with [MegaSquirt](http://www.msextra.com/) open-source engine controllers via CAN bus. It provides real-time GPS data including coordinates, time, altitude, and vehicle speed to the ECU for logging and display.
+This project leverages the [ESP32](https://www.espressif.com/en/products/socs/esp32) microcontroller to interface with [MegaSquirt](http://www.msextra.com/) open-source engine controllers via CAN bus. It provides real-time GPS data including coordinates, time, altitude, and vehicle speed and acceleration to the ECU for logging and display.
 
 ### Features
 * **CAN Bus Communication**: MegaSquirt extended frame protocol (29-bit) at 500 kbps
 * **GPS Integration**: u-blox binary protocol with multi-constellation support (GPS, GLONASS, Galileo, Beidou)
-* **Real-time Data**: GPS coordinates, UTC time, altitude, speed, and course
-* **JBPerf Compatible**: Uses same block/offset scheme as JBPerf IO Extender
+* **Accelerometer Integration**: 3-axis IMU data with automatic calibration (MPU6050)
+* **Real-time Data**: GPS coordinates, UTC time, altitude, course, speed, and acceleration
+* **JBPerf Compatible**: Uses same block/offset scheme as [JBPerf IO Extender Board](https://jbperf.com/io_extender/index.html)
 * **Debug Output**: Comprehensive serial logging for troubleshooting
 
 ## Hardware Required
 
 ### Core Components
 * [ESP-WROOM-32 + Expansion Board](https://www.amazon.com/gp/product/B0B82BBKCY) - ESP32 development board
-* [HGLRC Mini M100](https://www.amazon.com/gp/product/B0BX65QZJ8) - u-blox compatible 10Hz GPS module  
+* [HGLRC Mini M100](https://www.amazon.com/gp/product/B0BX65QZJ8) - u-blox compatible 10Hz GPS module
 * [SN65HVD230](https://www.amazon.com/gp/product/B07ZT7LLSK) - CAN Bus Transceiver Module
+* [MPU6050 IMU Module](https://www.amazon.com/dp/B01DK83ZYQ) - 6-axis accelerometer/gyroscope
 
 ## Libraries Required
+**FastIMU**
+- **Purpose**: IMU/accelerometer data processing (MPU6050 support)
+- **Repository**: [FastIMU](https://github.com/LiquidCGS/FastIMU)
+- **Features Used**: Accelerometer calibration, real-time sensor data
 
-**ESP32-TWAI-CAN**
-- **Purpose**: CAN bus communication for ESP32 using TWAI peripheral
-- **Repository**: [ESP32-TWAI-CAN](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/twai.html)
-- **Features Used**: Extended frame (29-bit) TX/RX, configurable speed, frame filtering
-
-### Included Libraries (Custom)
-
+### Included Libraries (Custom and modified)
 **qqqlab_GPS_UBLOX** (Included in project)
-- **Purpose**: u-blox GPS binary (UBX) protocol handler
-- **Origin**: Ported from ArduPilot AP_GPS_UBLOX (v4.5.7) 
+- **Purpose**: u-blox GPS binary (UBX) protocol handler with added date/time support
+- **Origin**: Ported from ArduPilot AP_GPS_UBLOX (v4.5.7)
 - **Modifications**: Platform agnostic, removed ArduPilot dependencies, no float usage
 - **Supported GPS**: u-blox M8N, M9N, M10, F9P series modules
-- **Features**: Auto-baud detection, GNSS configuration, real-time positioning
+- **Features**: GNSS configuration, real-time positioning
 
 ## Installation & Setup
 
@@ -45,7 +45,15 @@ This project leverages the [ESP32](https://www.espressif.com/en/products/socs/es
    - Tools → Board → Boards Manager → Search "ESP32" → Install
 
 2. **Select board:** ESP32 Dev Module
-3. **Install required libraries:** ESP32-TWAI-CAN (see Libraries section above)
+
+3. **Install required libraries:**
+
+   **Method 1: Arduino Library Manager (Recommended)**
+   - Tools → Manage Libraries
+   - Search "FastIMU" → Install by LiquidCGS
+
+   **Method 2: Manual Installation**
+   - FastIMU: Download from [GitHub](https://github.com/LiquidCGS/FastIMU) → Add .ZIP Library
 
 ### 2. Hardware Connections
 
@@ -54,9 +62,20 @@ This project leverages the [ESP32](https://www.espressif.com/en/products/socs/es
 ESP32    GPS Module
 -----    ----------
 GPIO16 → RX (GPS receives)
-GPIO17 → TX (GPS transmits)  
+GPIO17 → TX (GPS transmits)
 3.3V   → VCC
 GND    → GND
+```
+
+#### ESP32 to IMU (MPU6050)
+```
+ESP32    MPU6050
+-----    -------
+GPIO25 → SDA
+GPIO26 → SCL
+3.3V   → VCC
+GND    → GND
+AD0    → GND (sets I2C address to 0x68)
 ```
 
 #### ESP32 to CAN Transceiver (SN65HVD230)
@@ -76,7 +95,6 @@ SN65HVD230    CAN Bus
 CANH       → CAN High
 CANL       → CAN Low
 ```
-**Note**: Ensure proper 120Ω termination resistors on CAN bus ends.
 
 ## Technical Specifications
 
@@ -88,7 +106,7 @@ CANL       → CAN Low
 - **CAN Table ID**: 7 (configurable as `MS_CAN_TBL`)
 
 
-### GPS Configuration  
+### GPS Configuration
 - **Baud Rate**: 230,400 bps (auto-negotiated)
 - **Update Rate**: 100ms (10 Hz)
 - **Protocol**: u-blox UBX binary
@@ -98,29 +116,35 @@ CANL       → CAN Low
 ### Supported Data Requests (JBPerf IO Extender Compatible)
 | Offset | Data Type | Description | Response When |
 |--------|-----------|-------------|---------------|
-| 2      | Accelerometer | ADC 1-4 (placeholder) | Always (returns zeros) |
+| 2      | Accelerometer | 3-axis accelerometer data (12-bit normalized) | IMU available |
 | 110    | Real-time Clock | GPS UTC time | GPS time valid |
 | 128    | GPS Coordinates | Lat/Lng in deg/min format | GPS fix available |
-| 136    | GPS Status | Fix status, altitude, speed, course | Always |
+| 136    | GPS Status | Fix status, altitude, speed, course | GPS fix available |
 
 ## Configuration
 
 ### Pin Configuration
 Edit these defines in `MSCanBus.ino` to match your wiring:
 ```cpp
+// Debug Output
+#define DEBUG true    // Enable detailed serial logging
+
 // Hardware pins
 #define GPS_RX    16  // ESP32 pin connected to GPS TX
-#define GPS_TX    17  // ESP32 pin connected to GPS RX  
+#define GPS_TX    17  // ESP32 pin connected to GPS RX
 #define CAN_RX    21  // ESP32 pin connected to CAN transceiver RX
 #define CAN_TX    22  // ESP32 pin connected to CAN transceiver TX
+#define IMU_SDA   25  // ESP32 pin connected to IMU SDA
+#define IMU_SCL   26  // ESP32 pin connected to IMU SCL
 
 // MegaSquirt CAN IDs
 #define MS_CAN_ID 0   // MegaSquirt ECU CAN ID (usually 0)
 #define MY_CAN_ID 10  // This device's CAN ID (must match TunerStudio)
 #define MS_CAN_TBL 7  // This device's Table number (must match TunerStudio)
 
-// Debug Output
-#define DEBUG true    // Enable detailed serial logging
+// MegaSquirt CAN IDs
+#define IMU_GEOMETRY 0    //Set IMU geometry (check the reference [picture](https://github.com/LiquidCGS/FastIMU/raw/main/MountIndex.png)).
+MPU6050 IMU;              //Set to a supported by [FastIMU](https://github.com/LiquidCGS/FastIMU) IMU
 ```
 
 ### TunerStudio Setup
@@ -155,9 +179,22 @@ Got a CAN Frame for: 10 Got CAN Req
 
 ### Data Format Details
 
+#### Accelerometer Data (Offset 2)
+- Bytes 0-1: X-axis acceleration (12-bit, big-endian, ±4G normalized to 0-4095)
+- Bytes 2-3: Y-axis acceleration (12-bit, big-endian, ±4G normalized to 0-4095)
+- Bytes 4-5: Z-axis acceleration (12-bit, big-endian, ±4G normalized to 0-4095)
+- Bytes 6-7: Reserved (0x00)
+
+#### Accelerometer Status (every 1 second when DEBUG enabled)
+```
+AccelX: 0.002991 AccelY: -0.003235 AccelZ: 0.997864
+GyroX: 0.084204 GyroY: 0.151900 GyroZ: -0.265331
+IMU Temp: 24.774117
+```
+
 #### Time Data (Offset 110)
 - Byte 0: Seconds (0-59)
-- Byte 1: Minutes (0-59) 
+- Byte 1: Minutes (0-59)
 - Byte 2: Hours (0-23)
 - Byte 3: Reserved (0)
 - Byte 4: Day (1-31)
@@ -178,7 +215,7 @@ Got a CAN Frame for: 10 Got CAN Req
 ```
 MSCanBus/
 ├── MSCanBus.ino          # Main Arduino sketch
-├── MSCanBus.h            # MegaSquirt protocol definitions  
+├── MSCanBus.h            # MegaSquirt protocol definitions
 ├── qqqlab_GPS_UBLOX.h    # GPS driver header
 ├── qqqlab_GPS_UBLOX.cpp  # GPS driver implementation
 └── README.md             # This documentation
@@ -214,6 +251,7 @@ MSCanBus/
 ### Debug Information
 - **Serial Monitor**: 115200 baud for debug output
 - **GPS Status**: Check fix type and satellite count
+- **Accelerometer/Gyro Status**: Check X Y Z acceleration
 - **CAN Frames**: Monitor transmitted data for correctness
 - **Error Messages**: Look for validation failures or timeouts
 
@@ -221,6 +259,7 @@ MSCanBus/
 
 This project includes code from:
 - **ArduPilot Project**: qqqlab_GPS_UBLOX based on AP_GPS_UBLOX (GPL v3)
-- **Original Project**: ESP32 CAN and GPS integration code
+- **FastIMU Library**: IMU sensor integration by LiquidCGS (MIT License)
+- **MSCan_Gauge**: MegaSquirt CAN protocol implementation ([merkur2k/MSCan_Gauge](https://github.com/merkur2k/MSCan_Gauge))
 
 Compatible with JBPerf IO Extender protocol for MegaSquirt integration.


### PR DESCRIPTION
  - Implement 3-axis IMU data collection with automatic calibration
  - Add real accelerometer CAN response (offset 2) with 12-bit normalized data
  - Optimize memory usage with F() macro for debug strings
  - Update README with FastIMU installation instructions and wiring diagrams
  - Add IMU debug output and comprehensive documentation
  - Add necessary code attributions